### PR TITLE
Add cover dependency

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -3,6 +3,7 @@ all: build test
 deps:
 	go get github.com/golang/lint/golint
 	go get github.com/stretchr/testify/assert
+	go get golang.org/x/tools/cmd/cover
 	go get
 
 build: deps


### PR DESCRIPTION
<3

```
$ make
go get github.com/golang/lint/golint
go get github.com/stretchr/testify/assert
go get
go build cmd/hostess/hostess.go
go test -coverprofile=coverage.out; go tool cover -html=coverage.out -o coverage.html
go tool: no such tool "cover"; to install:
	go get golang.org/x/tools/cmd/cover
go tool: no such tool "cover"; to install:
	go get golang.org/x/tools/cmd/cover
make: *** [test] Error 3
```