### PR TITLE
Add support to on/off arguments in the list command and Fish shell completions

### DIFF
--- a/autocompletions/hostess.fish
+++ b/autocompletions/hostess.fish
@@ -1,0 +1,28 @@
+function list_domains
+  hostess list $argv | cut -d " " -f 1
+end
+
+complete -c hostess -x -n '__fish_use_subcommand' -a add -d 'Add or replace a hosts entry.'
+complete -c hostess -x -n '__fish_use_subcommand' -a aff -d 'Add or replace a hosts entry in an off state.'
+complete -c hostess -x -n '__fish_use_subcommand' -a has -d 'Exit code 0 if the domain is in your hostfile, 1 otherwise.'
+complete -c hostess -f -n '__fish_use_subcommand' -a fix -d 'Rewrite your hosts file.'
+complete -c hostess -x -n '__fish_use_subcommand' -a dump -d 'Dump your hostfile as JSON.'
+complete -c hostess -r -n '__fish_use_subcommand' -a apply -d 'Add entries from a JSON file.'
+
+complete -c hostess -f -n '__fish_use_subcommand' -a list -d 'List domains, target ips, and on/off status.'
+complete -c hostess -f -n '__fish_use_subcommand' -a ls -d 'List domains, target ips, and on/off status.'
+complete -c hostess -f -A -n '__fish_seen_subcommand_from list' -a off -d 'List only disabled domains.'
+complete -c hostess -f -A -n '__fish_seen_subcommand_from ls' -a off -d 'List only disabled domains.'
+complete -c hostess -f -A -n '__fish_seen_subcommand_from list' -a on -d 'List only enabled domains.'
+complete -c hostess -f -A -n '__fish_seen_subcommand_from ls' -a on -d 'List only enabled domains.'
+
+complete -c hostess -x -n '__fish_use_subcommand' -a del -d 'Remove a host entry.'
+complete -c hostess -x -n '__fish_use_subcommand' -a rm -d 'Remove a host entry.'
+complete -c hostess -f -A -n '__fish_seen_subcommand_from del' -a '(list_domains)'
+complete -c hostess -f -A -n '__fish_seen_subcommand_from rm' -a '(list_domains)'
+
+complete -c hostess -x -n '__fish_use_subcommand' -a off -d "Disable a domain (but don't remove it completely)."
+complete -c hostess -f -A -n '__fish_seen_subcommand_from off' -a '(list_domains on)'
+
+complete -c hostess -x -n '__fish_use_subcommand' -a on -d 'Re-enable a domain that was disabled.'
+complete -c hostess -f -A -n '__fish_seen_subcommand_from on' -a '(list_domains off)'

--- a/commands.go
+++ b/commands.go
@@ -193,6 +193,17 @@ func OnOff(c *cli.Context) {
 
 // Ls command shows a list of hostnames in the hosts file
 func Ls(c *cli.Context) {
+	var status bool
+	printall := true
+	if len(c.Args()) != 0 {
+		printall = false
+		status = false
+
+		if c.Args()[0] == "on" {
+			status = true
+		}
+	}
+
 	hostsfile := AlwaysLoadHostFile(c)
 	maxdomain := 0
 	maxip := 0
@@ -207,11 +218,21 @@ func Ls(c *cli.Context) {
 		}
 	}
 
-	for _, hostname := range hostsfile.Hosts {
+	printHost := func(hostname *Hostname) {
 		fmt.Printf("%s -> %s %s\n",
 			StrPadRight(hostname.Domain, maxdomain),
 			StrPadRight(hostname.IP.String(), maxip),
 			hostname.FormatEnabled())
+	}
+
+	for _, hostname := range hostsfile.Hosts {
+		if printall {
+			printHost(hostname)
+		} else {
+			if hostname.Enabled == status {
+				printHost(hostname)
+			}
+		}
 	}
 }
 

--- a/commands_test.go
+++ b/commands_test.go
@@ -2,6 +2,7 @@ package hostess
 
 import (
 	"flag"
+	"io/ioutil"
 	"os"
 	"testing"
 
@@ -15,9 +16,45 @@ func TestStrPadRight(t *testing.T) {
 	assert.Equal(t, "string", StrPadRight("string", 0), "6-length 0 padding")
 }
 
+func captureOutput(f func()) string {
+	rescueStdout := os.Stdout
+	r, w, _ := os.Pipe()
+	os.Stdout = w
+
+	f()
+
+	w.Close()
+	out, _ := ioutil.ReadAll(r)
+	os.Stdout = rescueStdout
+
+	return string(out[:])
+}
+
 func TestLs(t *testing.T) {
 	os.Setenv("HOSTESS_PATH", "test-fixtures/hostfile1")
 	defer os.Setenv("HOSTESS_PATH", "")
-	c := cli.NewContext(cli.NewApp(), &flag.FlagSet{}, nil)
-	Ls(c)
+
+	app := cli.NewApp()
+
+	context := cli.NewContext(app, &flag.FlagSet{}, nil)
+	Ls(context)
+
+	// Test on/off arguments functionality
+	os.Setenv("HOSTESS_PATH", "test-fixtures/ls_on_off")
+	set := flag.NewFlagSet("test", 0)
+	set.Parse([]string{"list", "on"})
+	context = cli.NewContext(app, set, nil)
+	command := cli.Command{
+		Name:        "list",
+		Aliases:     []string{"ls"},
+		Usage:       "Testing Ls",
+		Description: "Testing Ls",
+		Action:      Ls,
+	}
+
+	output := captureOutput(func() {
+		command.Run(context)
+	})
+
+	assert.Equal(t, "chocolate.pie.example.com      -> fe:23b3:890e:342e::ef (On)\n", output)
 }

--- a/test-fixtures/ls_on_off
+++ b/test-fixtures/ls_on_off
@@ -1,0 +1,2 @@
+# fe:23b3:890e:342e::ef dev.strawberry.pie.example.com
+fe:23b3:890e:342e::ef chocolate.pie.example.com


### PR DESCRIPTION
Hi,

I love the idea of hostess but without auto completing the available domains it was not as useful to me, so I decided to try to fix it.

I think that the best way of doing it is at a shell level, so I added a Fish shell completion script. I want to add completions to Bash and zsh as well but since I haven't used those in years it can take a little longer for me to figure that out.

To support the shell completions I added support to on/off arguments in the list command which should be useful in other situations as well.

Let me know what you think =D 
