### PR TITLE
Support saving hosts file on windows with admin rights

### DIFF
--- a/hostfile.go
+++ b/hostfile.go
@@ -192,12 +192,17 @@ func (h *Hostfile) Format() []byte {
 // Save writes the Hostfile to disk to /etc/hosts or to the location specified
 // by the HOSTESS_PATH environment variable (if set).
 func (h *Hostfile) Save() error {
-	file, err := os.OpenFile(h.Path, os.O_RDWR|os.O_APPEND|os.O_TRUNC, 0644)
+	file, err := os.OpenFile(h.Path, os.O_RDWR, 0644)
+	if err != nil {
+		return err
+	}
+	defer file.Close()
+
+	err = file.Truncate(0)
 	if err != nil {
 		return err
 	}
 
-	defer file.Close()
 	_, err = file.Write(h.Format())
 
 	return err


### PR DESCRIPTION
Relates to #27 

Using the proposed change by [tdaniely](https://github.com/cbednarski/hostess/issues/27#issuecomment-403453096).

Imo we can use this fix for now, but should try to find a better way.