### PR TITLE
Supports PREFIX variable on make install

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,4 +1,5 @@
 RELEASE_VERSION=$(shell git describe --tags)
+PREFIX ?= /usr/local
 
 test:
 	go test ./...
@@ -6,7 +7,7 @@ test:
 
 install:
 	go build -o bin/hostess .
-	sudo mv bin/hostess /usr/local/bin/hostess
+	install -C bin/hostess -t ${PREFIX}/bin
 
 release: test
 	GOOS=windows GOARCH=amd64 go build -ldflags "-X main.Version=${RELEASE_VERSION}" -o bin/hostess_windows_amd64.exe .

--- a/README.md
+++ b/README.md
@@ -22,7 +22,12 @@ from GitHub, or build from source (with a [recent version of Go](https://golang.
 
     git clone https://github.com/cbednarski/hostess
     cd hostess
-    make install
+    sudo make install # installs using /usr/local as a prefix
+
+You can also specify a PREFIX variable to install to a different path:
+
+    cd hostess
+    PREFIX=/home/me/.local make install
 
 ## Usage
 


### PR DESCRIPTION
Some systems might not have sudo (I used to not have it for a long time). Also, letting the user specify the install path is always a good idea (I have a lot of software installed to `.local/bin`). This pull requests adds the option to use the PREFIX variable to set the install path.